### PR TITLE
Exclude xml files from filtering.

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -109,6 +109,7 @@ filters_exclude[15]='\.ttf$'
 filters_exclude[16]='\.woff$'
 filters_exclude[17]='\.eot$'
 filters_exclude[18]='\.svg$'
+filters_exclude[19]='\.xml$'
 
 # Additional excludes specific to this project
 # filters_exclude[15]=''


### PR DESCRIPTION
I think we should exclude .xml files. Here is a warning for my Phing build.xml file.
```
--------------------------------------------------------------------------------
FOUND 0 ERROR(S) AND 1 WARNING(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 1 | WARNING | No PHP code was found in this file and short open tags are not
   |         | allowed by this install of PHP. This file may be using short
   |         | open tags but PHP does not allow them.
--------------------------------------------------------------------------------
```