### PR TITLE
If vendor/bin is not in path, we may not find phpcs

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -143,6 +143,10 @@ do
       #################################
 
       # Get the PHP Codesniffer bin path
+      if [ -d vendor/bin ]
+      then
+        PATH=vendor/bin:$PATH
+      fi
       PHPCS_BIN=$(which phpcs)
 
       # Default PHP error code


### PR DESCRIPTION
If phpcs is in vendor/bin we should find that "automagically". But if vendor/bin/is not in path, we don't.